### PR TITLE
use pkginfo to determine axios version for http adapter

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -9,9 +9,9 @@ var httpFollow = require('follow-redirects').http;
 var httpsFollow = require('follow-redirects').https;
 var url = require('url');
 var zlib = require('zlib');
-var pkg = require('./../../package.json');
 var createError = require('../core/createError');
 var enhanceError = require('../core/enhanceError');
+var pkginfo = require('pkginfo')(module);
 
 /*eslint consistent-return:0*/
 module.exports = function httpAdapter(config) {
@@ -24,7 +24,7 @@ module.exports = function httpAdapter(config) {
     // Only set header if it hasn't been set in config
     // See https://github.com/axios/axios/issues/69
     if (!headers['User-Agent'] && !headers['user-agent']) {
-      headers['User-Agent'] = 'axios/' + pkg.version;
+      headers['User-Agent'] = 'axios/' + pkginfo.version;
     }
 
     if (data && !utils.isStream(data)) {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   "typings": "./index.d.ts",
   "dependencies": {
     "follow-redirects": "^1.2.5",
-    "is-buffer": "^1.1.5"
+    "is-buffer": "^1.1.5",
+    "pkginfo": "^0.4.1"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
Webpack alias/definePlugin or sth similar is actually not needed since the `User-Agent` is not set in the xhr adapter.

--> this is node only, we can use the plugin without getting bundle size problems.